### PR TITLE
Fix for sublime-jsoncomma issue #20

### DIFF
--- a/internals/jsoncommas.go
+++ b/internals/jsoncommas.go
@@ -307,7 +307,11 @@ func (f *Fixer) Flush() error {
 
 var readersPool = sync.Pool{
 	New: func() interface{} {
-		return bufio.NewReader(nil)
+		// TODO: add this max-size as user setting for plugins
+		// or calculate needed buffer-size by parsing the request body firts
+		// I'm a total noob in Go so I dont know how to pass the buffersize to here...
+		return bufio.NewReaderSize(nil,15000) // increase max buffer size
+		// the standard max buffer size depends on the OS but was found to be 4096 bytes in my case
 	},
 }
 var writersPool = sync.Pool{


### PR DESCRIPTION
This will half-fix the issue of cutting large jsons after a fixed size, by specifying a new max-size.

The new maximum size is set to 15000 bytes, as I am not experienced enough to set the maximum size according to the json-size. 
If anybody knows how to apply the json-size as the new buffer-max-size pls do so. I have already calculated the json size, but I don't know how to pass this information to the necessary function...

 @jsoncomma: I hope this will get merged soon and the executeables are updated as well. Let me know if anything is unclear 